### PR TITLE
Limit the image build to amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: device-management-service/native-platform        
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           build-args: |
             - REVISION=${{ github.ref_name }}
           push: true

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Build mock xconf image
         uses: docker/build-push-action@v4
         with:
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           context: device-management-service/mock-xconf
           push: true
           tags: localhost:5000/mockxconf:latest


### PR DESCRIPTION
This is to check the recent crashes in libtool found only with GH actions. 
If this fixes the issues will have to bring back multiplatform support via matrix strategy.