### PR TITLE
Remove reuse of built containers.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-  
-      - name: Pull docker images
-        run: |
-          docker pull ghcr.io/rdkcentral/docker-device-mgt-service-test/mockxconf:latest
-          docker pull ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform:latest          
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -32,11 +32,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull docker images
-        run: |
-          docker pull ghcr.io/rdkcentral/docker-device-mgt-service-test/mockxconf:latest
-          docker pull ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform:latest
-
       - name: Checkout docker config repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The self-signed cert dumps are creating mismatches from cache build