### PR TITLE
RDKEMW-1524: Upgrade tr69hostif to libsoup-3.0

### DIFF
--- a/native-platform/Dockerfile
+++ b/native-platform/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get install -y gdb valgrind lcov g++ wget gperf curl
 
 RUN apt-get update && apt-get install -y libjsonrpccpp-dev
 
+# Add libsoup-3.0 support
+RUN apt-get update && apt-get install -y libsoup-3.0
+
 # Add additional pytest packages 
 RUN apt-get update && apt-get install -y \
     python3-pytest python3-pytest-cov software-properties-common


### PR DESCRIPTION
Reason for change: Upgrade tr69hostif to libsoup-3.0
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)