### PR TITLE
Aligning the image names between local and remote

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@
 # limitations under the License.
 ##########################################################################
 
-REGISTRY_ROOT="ghcr.io"
+REGISTRY_ROOT="ghcr.io/rdkcentral"
 REPOSITORY_NAME="docker-device-mgt-service-test"
 
 # Build container that provides mock xconf service

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   mock-xconf:
-    image: "ghcr.io/docker-device-mgt-service-test/mockxconf:latest"
+    image: "ghcr.io/rdkcentral/docker-device-mgt-service-test/mockxconf:latest"
     container_name: "mockxconf"
     ports:
       - "50050:50050"
@@ -13,7 +13,7 @@ services:
 
 
   l2-container:
-    image: "ghcr.io/docker-device-mgt-service-test/native-platform:latest"
+    image: "ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform:latest"
     container_name: "native-platform"
     ports:   
       - "9090:9090"  
@@ -25,7 +25,7 @@ services:
       - NET_ADMIN
   
   nmap-container:
-    image: "ghcr.io/docker-device-mgt-service-test/native-platform:latest"
+    image: "ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform:latest"
     container_name: "nmap-platform"  
     depends_on:
       - mock-xconf


### PR DESCRIPTION
The docker image name used in local build and compose file was missing the org names.
No changes in the artifacts deployed in registry and workflows.